### PR TITLE
Fix mini typo

### DIFF
--- a/nspanel_blueprint.yaml
+++ b/nspanel_blueprint.yaml
@@ -861,7 +861,7 @@ blueprint:
             default: [31, 169, 255]
             selector: *color_selector
           hw_buttons_bar_color_off:
-            name: Hardware baby-carriageuttons - Bar color when `Off` (Optional)
+            name: Hardware Buttons - Bar color when `Off` (Optional)
             description: "Choose a color for the button's bars when the controlled entity is `Off`."
             default: [44, 44, 44]
             selector: *color_selector


### PR DESCRIPTION
Most probably, due to a copy/paste error, the description of a config item is incorrect